### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "jira-rest-typescript",
+  "version": "1.0.0",
+  "repository": "https://github.com/robertkaucher/jira-rest-typescript",
+  "author": "robertkaucher",
+  "license": "MIT"
+}


### PR DESCRIPTION
Here is proposal, to be able to run something like `yarn add https://github.com/robertkaucher/jira-rest-typescript` without even publishing it to npm, package.json is required

After that we can use definitions like so:

```
import IUser = jira.IUser

let user: IUser = {
    name: 'mac'
}

console.log(user)
```

not sure if it is a right way, but got up and running in my web storm setup, from now on I do not need to manually replicate all interfaces, thank you for your work